### PR TITLE
Add API export helpers and docs

### DIFF
--- a/sell-that-sheet/README.md
+++ b/sell-that-sheet/README.md
@@ -40,6 +40,12 @@ Each element is well presented in a very complex documentation. You can read
 more about the <a href="https://horizon-ui.com/documentation/docs/introduction?ref=readme-horizon" target="_blank">documentation
 here.</a>
 
+### Frontend Integration Guide
+
+This repository includes additional helpers for working with the `sell-that-sheet` API.
+See [docs/frontend_integration.md](docs/frontend_integration.md) for details on
+CSV conversion and export endpoints. You can use these endpoints from the **Eksporter danych** page in the dashboard.
+
 ### Quick Start
 
 Install Horizon UI by running either of the following:

--- a/sell-that-sheet/docs/frontend_integration.md
+++ b/sell-that-sheet/docs/frontend_integration.md
@@ -1,0 +1,31 @@
+# Frontend Integration Guide
+
+This document explains how to use the API endpoints that were recently added to `sell-that-sheet`.
+
+## CSV to XLSX Conversion
+
+`POST /utils/rows-to-columns/`
+
+Upload a CSV file in a `file` form field. The endpoint returns an XLSX blob named `converted.xlsx`.
+
+Example using the helpers from `AuthContext`:
+
+```javascript
+const file = /* File object from `<input type="file" />` */;
+const blob = await convertRowsToColumns(file);
+// use URL.createObjectURL(blob) to trigger a download
+```
+
+## Export Allegro Products
+
+1. `POST /allegro/export/start/` – starts a Celery task and returns `{"task_id": "<id>"}`.
+2. `GET /allegro/export/download/` – download `full_catalogue.xlsx` once ready. Returns `404` while the task runs.
+
+Call `startAllegroExport()` and poll with `downloadAllegroExport()` until a Blob is returned.
+
+## Export Auction Data
+
+1. `GET /auctions/export/` – starts the export task and returns `{"task_id": "<id>"}`.
+2. `GET /auctions/export/download/` – download `auctions_export.xlsx` once available. Returns `404` until then.
+
+Use `startAuctionExport()` and `downloadAuctionExport()` similarly to the Allegro helpers.

--- a/sell-that-sheet/src/components/dataExporter/DataExporter.jsx
+++ b/sell-that-sheet/src/components/dataExporter/DataExporter.jsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import {
+  Box,
+  VStack,
+  Heading,
+  Button,
+  Input,
+  Text,
+  HStack,
+  useToast,
+} from "@chakra-ui/react";
+import {
+  convertRowsToColumns,
+  startAllegroExport,
+  downloadAllegroExport,
+  startAuctionExport,
+  downloadAuctionExport,
+} from "contexts/AuthContext";
+
+const DataExporter = () => {
+  const [csvFile, setCsvFile] = useState(null);
+  const [allegroRunning, setAllegroRunning] = useState(false);
+  const [auctionRunning, setAuctionRunning] = useState(false);
+  const toast = useToast();
+
+  const downloadBlob = (blob, filename) => {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const handleConvert = async () => {
+    if (!csvFile) return;
+    try {
+      const blob = await convertRowsToColumns(csvFile);
+      downloadBlob(blob, "converted.xlsx");
+      toast({ title: "Plik zapisany", status: "success", duration: 3000, isClosable: true });
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Błąd konwersji", status: "error", duration: 3000, isClosable: true });
+    }
+  };
+
+  const pollAllegro = async () => {
+    const blob = await downloadAllegroExport();
+    if (blob) {
+      downloadBlob(blob, "full_catalogue.xlsx");
+      setAllegroRunning(false);
+      toast({ title: "Pobrano katalog", status: "success", duration: 3000, isClosable: true });
+    } else {
+      setTimeout(pollAllegro, 5000);
+    }
+  };
+
+  const handleAllegroExport = async () => {
+    try {
+      setAllegroRunning(true);
+      await startAllegroExport();
+      pollAllegro();
+    } catch (err) {
+      setAllegroRunning(false);
+      toast({ title: "Błąd eksportu", status: "error", duration: 3000, isClosable: true });
+    }
+  };
+
+  const pollAuction = async () => {
+    const blob = await downloadAuctionExport();
+    if (blob) {
+      downloadBlob(blob, "auctions_export.xlsx");
+      setAuctionRunning(false);
+      toast({ title: "Pobrano aukcje", status: "success", duration: 3000, isClosable: true });
+    } else {
+      setTimeout(pollAuction, 5000);
+    }
+  };
+
+  const handleAuctionExport = async () => {
+    try {
+      setAuctionRunning(true);
+      await startAuctionExport();
+      pollAuction();
+    } catch (err) {
+      setAuctionRunning(false);
+      toast({ title: "Błąd eksportu", status: "error", duration: 3000, isClosable: true });
+    }
+  };
+
+  return (
+    <Box p={4} maxW="600px" mx="auto">
+      <VStack spacing={8} align="stretch">
+        <Heading size="lg">Eksporter danych</Heading>
+
+        <Box>
+          <Heading size="md" mb={2}>Konwertuj CSV na XLSX</Heading>
+          <HStack>
+            <Input type="file" accept=".csv" onChange={(e) => setCsvFile(e.target.files[0])} />
+            <Button colorScheme="blue" onClick={handleConvert} isDisabled={!csvFile}>Konwertuj</Button>
+          </HStack>
+        </Box>
+
+        <Box>
+          <Heading size="md" mb={2}>Eksportuj produkty Allegro</Heading>
+          <Button colorScheme="blue" onClick={handleAllegroExport} isLoading={allegroRunning}>
+            Rozpocznij eksport
+          </Button>
+          {allegroRunning && <Text mt={2}>Trwa generowanie pliku...</Text>}
+        </Box>
+
+        <Box>
+          <Heading size="md" mb={2}>Eksportuj aukcje</Heading>
+          <Button colorScheme="blue" onClick={handleAuctionExport} isLoading={auctionRunning}>
+            Rozpocznij eksport
+          </Button>
+          {auctionRunning && <Text mt={2}>Trwa generowanie pliku...</Text>}
+        </Box>
+      </VStack>
+    </Box>
+  );
+};
+
+export default DataExporter;

--- a/sell-that-sheet/src/contexts/AuthContext.js
+++ b/sell-that-sheet/src/contexts/AuthContext.js
@@ -689,4 +689,61 @@ export const fetchBaselinkerInventories = async () => {
   return response.data;
 };
 
+// Convert uploaded CSV rows into XLSX columns
+export const convertRowsToColumns = async (file) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await api.post("/utils/rows-to-columns/", formData, {
+    responseType: "blob",
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+
+  return response.data;
+};
+
+// Trigger Allegro catalogue export
+export const startAllegroExport = async () => {
+  const response = await api.post("/allegro/export/start/");
+  return response.data;
+};
+
+// Download Allegro catalogue once ready
+export const downloadAllegroExport = async () => {
+  try {
+    const response = await api.get("/allegro/export/download/", {
+      responseType: "blob",
+      validateStatus: (status) => status === 200 || status === 404,
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// Start auction export task
+export const startAuctionExport = async () => {
+  const response = await api.get("/auctions/export/");
+  return response.data;
+};
+
+// Download auction export once ready
+export const downloadAuctionExport = async () => {
+  try {
+    const response = await api.get("/auctions/export/download/", {
+      responseType: "blob",
+      validateStatus: (status) => status === 200 || status === 404,
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export { api };

--- a/sell-that-sheet/src/routes.js
+++ b/sell-that-sheet/src/routes.js
@@ -9,6 +9,7 @@ import {
   MdOutlineShoppingCart,
   MdBlurLinear,
   MdGTranslate,
+  MdDownload,
 } from "react-icons/md";
 import { RiTranslate } from "react-icons/ri";
 import { FaTag, FaTags } from "react-icons/fa";
@@ -29,6 +30,7 @@ import TagsManagerView from "views/admin/tagsManager";
 import CategoryTagsManagerView from "views/admin/categoryTagsManager";
 import CustomParameterManagerView from "views/admin/customParameterManager";
 import BaselinkerProductTranslation from "views/admin/baselinkerProductTranslation";
+import DataExporterView from "views/admin/dataExporter";
 
 const routes = [
   {
@@ -115,6 +117,13 @@ const routes = [
     path: "/baselinker-product-translation",
     icon: <Icon as={RiTranslate} width="20px" height="20px" color="inherit" />,
     component: BaselinkerProductTranslation,
+  },
+  {
+    name: "Eksporter danych",
+    layout: "/admin",
+    path: "/data-exporter",
+    icon: <Icon as={MdDownload} width="20px" height="20px" color="inherit" />,
+    component: DataExporterView,
   },
   // {
   //   name: "RTL Admin",

--- a/sell-that-sheet/src/views/admin/dataExporter/index.jsx
+++ b/sell-that-sheet/src/views/admin/dataExporter/index.jsx
@@ -1,0 +1,24 @@
+/*!
+  _   _  ___  ____  ___ ________  _   _   _   _ ___
+ | | | |/ _ \|  _ \|_ _|__  / _ \| \ | | | | | |_ _|
+ | |_| | | | | |_) || |  / / | | |  \| | | | | || |
+ |  _  | |_| |  _ < | | / /| |_| | |\  | | |_| || |
+ |_| |_|\___/|_| \_\___/____\___/|_| \_|  \___/|___|
+*/
+
+import { Box, SimpleGrid, useColorModeValue } from "@chakra-ui/react";
+import React from "react";
+import DataExporter from "components/dataExporter/DataExporter";
+
+export default function DataExporterView() {
+  const brandColor = useColorModeValue("brand.500", "white");
+  const boxBg = useColorModeValue("secondaryGray.300", "whiteAlpha.100");
+
+  return (
+    <Box pt={{ base: "130px", md: "80px", xl: "80px" }}>
+      <SimpleGrid columns={{ base: 1, md: 1, xl: 1 }} gap="20px" mb="20px" mt="20px">
+        <DataExporter />
+      </SimpleGrid>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- document the new export/convert endpoints
- expose helpers for conversion and export in AuthContext
- add Eksporter danych page for converting CSV files and downloading exports

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472d3d5d988328ae0913ec8a66add0